### PR TITLE
Run launcher instead of game itself

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,7 +30,7 @@ apps:
     extensions: [ gnome-3-28 ]
     command: bin/sommelier run-exe
     environment:
-      RUN_EXE: "C:/Program Files (x86)/TmNationsForever/TmForever.exe"
+      RUN_EXE: "C:/Program Files (x86)/TmNationsForever/TmForeverLauncher.exe"
       INSTALL_URL: "http://files.trackmaniaforever.com/tmnationsforever_setup.exe"
       INSTALL_FLAGS: "/silent"
       SOMMELIER_VIRTDESKTOP: 1


### PR DESCRIPTION
As explained in https://github.com/snapcrafters/tmnationsforever/issues/18, on Windows, the launcher runs first instead of the game itself. The launcher has a bunch of useful options for display, audio and network. I think we should also run the launcher instead of the game, since these settings can be useful for network issues like in https://github.com/snapcrafters/tmnationsforever/issues/29 (that CLI flag option is also available using the advanced settings GUI of the launcher)

This PR updates the app to run the launcher instead of the game itself.

Fixes #18
Fixes #29